### PR TITLE
Issue #8

### DIFF
--- a/app/src/main/java/com/health/openworkout/core/datatypes/WorkoutSession.java
+++ b/app/src/main/java/com/health/openworkout/core/datatypes/WorkoutSession.java
@@ -104,7 +104,13 @@ public class WorkoutSession implements Comparable<WorkoutSession>, Cloneable {
         return workoutItems;
     }
 
-    public WorkoutItem getNextWorkoutItem() {
+    public WorkoutItem getNextWorkoutItem(long workoutItemOrderNr) {
+        // Run two iterations. In the first one check only future workoutItems. In the second one, check also workoutItems at the beginning.
+        for (WorkoutItem workoutItem : workoutItems) {
+            if (!workoutItem.isFinished() && workoutItem.getOrderNr() > workoutItemOrderNr) {
+                return workoutItem;
+            }
+        }
         for (WorkoutItem workoutItem : workoutItems) {
             if (!workoutItem.isFinished()) {
                 return workoutItem;

--- a/app/src/main/java/com/health/openworkout/gui/workout/WorkoutSlideFragment.java
+++ b/app/src/main/java/com/health/openworkout/gui/workout/WorkoutSlideFragment.java
@@ -77,6 +77,7 @@ public class WorkoutSlideFragment extends Fragment {
     private SoundUtils soundUtils;
 
     private WorkoutSession workoutSession;
+    private long workoutItemOrderNr;
     private WorkoutItem nextWorkoutItem;
     private WORKOUT_STATE workoutState;
     private long workoutItemIdFromFragment;
@@ -211,12 +212,13 @@ public class WorkoutSlideFragment extends Fragment {
     private void nextWorkout() {
         // if no workout item was selected use the next not finished workout item in the session list
         if (workoutItemIdFromFragment == -1L) {
-            if (workoutSession.getNextWorkoutItem() == null) {
+            workoutItemOrderNr = nextWorkoutItem.getOrderNr();  // Get current orderNr before updating to nextWorkoutItem
+            if (workoutSession.getNextWorkoutItem(workoutItemOrderNr) == null) {
                 onFinishSession();
                 return;
             }
 
-            nextWorkoutItem = workoutSession.getNextWorkoutItem();
+            nextWorkoutItem = workoutSession.getNextWorkoutItem(workoutItemOrderNr);
         } else {
             // otherwise use the workout item as a starting point which was selected in the workout fragment
             for (WorkoutItem workoutItem : workoutSession.getWorkoutItems()) {


### PR DESCRIPTION
	Changed: getNextWorkoutItem requires now the current workoutOrderNr. It searches first for future unfinished workouts and afterwards for previous unfinished workouts.

On branch iss8
Changes to be committed:
	modified:   app/src/main/java/com/health/openworkout/core/datatypes/WorkoutSession.java
	modified:   app/src/main/java/com/health/openworkout/gui/workout/WorkoutSlideFragment.java