### PR TITLE
Add FLAG_IMMUTABLE to prevent Error when Activating Reminder

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -22,7 +22,7 @@
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED" />
     <uses-permission android:name="android.permission.INTERNET" />
-
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS" />
     <application
         android:allowBackup="true"
         android:icon="@drawable/ic_openworkout"

--- a/app/src/main/java/com/health/openworkout/core/alarm/AlarmHandler.java
+++ b/app/src/main/java/com/health/openworkout/core/alarm/AlarmHandler.java
@@ -90,7 +90,7 @@ public class AlarmHandler {
         Intent alarmIntent = new Intent(context, ReminderBootReceiver.class);
         alarmIntent.putExtra(INTENT_EXTRA_ALARM, true);
 
-        return PendingIntent.getBroadcast(context, dayOfWeek, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+        return PendingIntent.getBroadcast(context, dayOfWeek, alarmIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
     }
 
     public void disableAllAlarms(Context context) {
@@ -110,7 +110,7 @@ public class AlarmHandler {
         Intent notifyIntent = new Intent(context, MainActivity.class);
 
         PendingIntent notifyPendingIntent =
-                PendingIntent.getActivity(context, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT);
+                PendingIntent.getActivity(context, 0, notifyIntent, PendingIntent.FLAG_UPDATE_CURRENT | PendingIntent.FLAG_IMMUTABLE);
 
         NotificationCompat.Builder mBuilder = new NotificationCompat.Builder(context, "openWorkout_notify");
 


### PR DESCRIPTION
Add FLAG_IMMUTABLE to prevent Error when Activating Reminder.

https://stackoverflow.com/questions/67045607/how-to-resolve-missing-pendingintent-mutability-flag-lint-warning-in-android-a